### PR TITLE
Update files on branch smartshift-thomasuster-1687982962

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "my-app",
       "version": "0.1.0",
       "dependencies": {
-        "react": "^15.6.1",
+        "react": "^18.2.0",
         "react-dom": "^15.6.1",
         "react-scripts": "1.0.10"
       }
@@ -2931,15 +2931,6 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
-      }
-    },
-    "node_modules/create-react-class": {
-      "version": "15.7.0",
-      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.7.0.tgz",
-      "integrity": "sha512-QZv4sFWG9S5RUvkTYWbflxeZX+JG7Cz0Tn33rQBJ+WFQTqTfUTjMjiv9tnfXazjsO5r0KhPs+AqCjyrQX6h2ng==",
-      "dependencies": {
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
       }
     },
     "node_modules/cross-spawn": {
@@ -11073,15 +11064,11 @@
       }
     },
     "node_modules/react": {
-      "version": "15.7.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-15.7.0.tgz",
-      "integrity": "sha512-5/MMRYmpmM0sMTHGLossnJCrmXQIiJilD6y3YN3TzAwGFj6zdnMtFv6xmi65PHKRV+pehIHpT7oy67Sr6s9AHA==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "dependencies": {
-        "create-react-class": "^15.6.0",
-        "fbjs": "^0.8.9",
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.0",
-        "prop-types": "^15.5.10"
+        "loose-envify": "^1.1.0"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -15512,8 +15499,7 @@
     "ajv-keywords": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-      "integrity": "sha512-vuBv+fm2s6cqUyey2A7qYcvsik+GMDJsw8BARP2sDE76cqmaZVarsvHf7Vx6VJ0Xk8gLl+u3MoAPf6gKzJefeA==",
-      "requires": {}
+      "integrity": "sha512-vuBv+fm2s6cqUyey2A7qYcvsik+GMDJsw8BARP2sDE76cqmaZVarsvHf7Vx6VJ0Xk8gLl+u3MoAPf6gKzJefeA=="
     },
     "align-text": {
       "version": "0.1.4",
@@ -17934,15 +17920,6 @@
         "sha.js": "^2.4.8"
       }
     },
-    "create-react-class": {
-      "version": "15.7.0",
-      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.7.0.tgz",
-      "integrity": "sha512-QZv4sFWG9S5RUvkTYWbflxeZX+JG7Cz0Tn33rQBJ+WFQTqTfUTjMjiv9tnfXazjsO5r0KhPs+AqCjyrQX6h2ng==",
-      "requires": {
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
-      }
-    },
     "cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
@@ -18788,8 +18765,7 @@
     "eslint-config-react-app": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-1.0.5.tgz",
-      "integrity": "sha512-nA3AYTMUGKVYH1goOp72fFdj33mxC1rElATOLDrCMbbhmtVz4K61NxKBc6vj9OwjugROioF2LYXZMZIFAfFozA==",
-      "requires": {}
+      "integrity": "sha512-nA3AYTMUGKVYH1goOp72fFdj33mxC1rElATOLDrCMbbhmtVz4K61NxKBc6vj9OwjugROioF2LYXZMZIFAfFozA=="
     },
     "eslint-import-resolver-node": {
       "version": "0.2.3",
@@ -24370,15 +24346,11 @@
       }
     },
     "react": {
-      "version": "15.7.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-15.7.0.tgz",
-      "integrity": "sha512-5/MMRYmpmM0sMTHGLossnJCrmXQIiJilD6y3YN3TzAwGFj6zdnMtFv6xmi65PHKRV+pehIHpT7oy67Sr6s9AHA==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "requires": {
-        "create-react-class": "^15.6.0",
-        "fbjs": "^0.8.9",
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.0",
-        "prop-types": "^15.5.10"
+        "loose-envify": "^1.1.0"
       }
     },
     "react-dev-utils": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "react": "^15.6.1",
+    "react": "^18.2.0",
     "react-dom": "^15.6.1",
     "react-scripts": "1.0.10"
   },

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -4,5 +4,5 @@ import App from './App';
 
 it('renders without crashing', () => {
   const div = document.createElement('div');
-  ReactDOM.render(<App />, div);
+  ReactDOM.createRoot(div).render(<App />);
 });

--- a/src/index.js
+++ b/src/index.js
@@ -4,5 +4,5 @@ import './index.css';
 import App from './App';
 import registerServiceWorker from './registerServiceWorker';
 
-ReactDOM.render(<App />, document.getElementById('root'));
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);
 registerServiceWorker();


### PR DESCRIPTION
Please review and merge these changes.
Explanations:
migrations/test/harfoots/sample-react17-app/src/App.test.js:
The changes in this git diff are about the migration from using `ReactDOM.render` to `createRoot` for rendering React components. 

In the original version, `ReactDOM` was being imported from 'react-dom'. The `ReactDOM.render` function was then used to render the App component into a div.

However, in the updated version, instead of importing the whole `ReactDOM` object, only `createRoot` is being imported from 'react-dom/client'. The `createRoot` method is a part of the new React concurrent mode API. This API enables more control over how updates get scheduled and rendered. 

After creating a div, `createRoot` is used on the div to create a root, then the `root.render` method is used to render the App component. This is the new recommended way to render React components as it enables concurrent features. 

This change is made to improve the app's responsiveness by enabling it to better utilize the browser's ability to manage multiple tasks concurrently, thus potentially improving performance.

migrations/test/harfoots/sample-react17-app/src/App.test.js:
This git diff is showing the changes made to replace a callback from a render function with a useEffect hook inside a component, following the prescribed migration task. Here's the detailed breakdown of the changes:

1. The React import is updated to also import `useEffect` from 'react'. This is a built-in hook in React that allows you to perform side effects in function components. It is going to replace the callback in the render function.

2. The import of `createRoot` from 'react-dom/client' is removed. `createRoot` is an experimental API for concurrent mode in React, but the code is being refactored to use the traditional `ReactDOM.render`.

3. The ReactDOM import is added. This is a more traditional way of rendering react components and it is replacing the `createRoot` function.

4. A new function component `AppWithCallbackAfterRender` is created. This component includes a `useEffect` hook that logs 'rendered' to the console every time the component is rendered. This is the replacement of the callback in the render function.

5. The `useEffect` hook is used without a dependency array, which means it will run after every render, effectively replacing the callback which was previously in the render function.

6. Inside the test function, instead of creating a root and rendering the `App` component with the `createRoot` function, the `ReactDOM.render` function is used to render the new `AppWithCallbackAfterRender` component. 

In summary, this migration task has replaced the experimental concurrent mode rendering with traditional rendering and moved the callback function from the render method to a `useEffect` hook inside the `AppWithCallbackAfterRender` component.

migrations/test/harfoots/sample-react17-app/src/App.test.js:
This git diff shows changes made to the code where deprecated ReactDOM methods are replaced with their new equivalents as a part of a React migration task. 

Here's a breakdown of the code changes:

1. The `useEffect` hook imported from React and the function `AppWithCallbackAfterRender` which uses this hook have been removed. This function was initially used to log a message ("rendered") every time the component renders.

2. The deprecated `ReactDOM.render` method has been replaced with the new `ReactDOM.createRoot(...).render(...)` method. 

3. Instead of rendering `AppWithCallbackAfterRender`, now we are rendering the `App` component directly. 

In the new Concurrent React (also known as React 18), ReactDOM.createRoot is the new API to render the react app. It's a part of the concurrent mode APIs which enables more reactive UIs by allowing React to interrupt a long-running render to handle a high-priority event. This is a replacement for the now deprecated ReactDOM.render method.

migrations/test/harfoots/sample-react17-app/src/index.js:
The changes in the given git diff are made to replace the traditional ReactDOM.render method with the new concurrent mode API, createRoot, which is a part of React's experimental concurrent mode features.

Here is a detailed explanation of the changes made:

- The import statement has been changed from importing ReactDOM to importing createRoot from 'react-dom/client'. This is done because createRoot is not a method on the ReactDOM object, but is a standalone export from 'react-dom/client'.

- Instead of using ReactDOM.render to render the <App /> component, we first get a reference to the root DOM node with `document.getElementById('root')` and store it in a variable named `container`.

- Then, we create a root using the `createRoot` method with the `container` as an argument, and store the returned root in a variable named `root`.

- Finally, we call the `render` method on the `root` object to render the <App /> component.

The call to registerServiceWorker() remains the same as it does not relate to the ReactDOM.render to createRoot migration.

Also, it's worth noting that the createRoot API is part of the React's experimental concurrent mode and is not yet available in the stable release. The concurrent mode allows React to interrupt a long-running render to handle a high-priority event.

migrations/test/harfoots/sample-react17-app/src/index.js:
The changes in this git diff are related to the removal of a callback from the render function and its replacement with a useEffect hook inside the component. 

Here's the explanation for each change:

1. `import React from 'react';` to `import React, { useEffect } from 'react';`: This change is to import the `useEffect` hook from the 'react' library. `useEffect` is a hook provided by React that allows us to perform side effects in function components.

2. `import { createRoot } from 'react-dom/client';` to `import ReactDOM from 'react-dom';`: This change is made because we no longer use `createRoot` for rendering, instead we use `ReactDOM.render`.

3. The following block of code was removed:
```
const container = document.getElementById('root');
const root = createRoot(container);
root.render(<App />);
``` 
This code was used to create a root node and render the `App` component on this node. 

4. The following function `AppWithCallbackAfterRender` was introduced:
```
function AppWithCallbackAfterRender() {
  useEffect(() => {
    console.log('rendered');
  }, []);
  return <App />
}
```
This is a React function component that wraps the `App` component. Inside this component, the `useEffect` hook is used. This hook will run the callback function that logs 'rendered' to the console every time the component is rendered. 

5. `ReactDOM.render(<AppWithCallbackAfterRender />, document.getElementById('root'));`: This line was added to render the `AppWithCallbackAfterRender` component into the root node in the DOM. This replaces the previous render method which has been removed.

6. Finally, `registerServiceWorker();` remains unchanged. This line of code registers a service worker, which can help in offline functionality of the app.

migrations/test/harfoots/sample-react17-app/src/index.js:
The above git diff shows the changes made to the file to replace the deprecated ReactDOM methods with their new equivalents.

1. The function `AppWithCallbackAfterRender` has been removed. This function used the `useEffect` React hook to log 'rendered' whenever the component was rendered. The `useEffect` import has also been removed since it is no longer needed.

2. The `ReactDOM.render` method, which was previously used to render the `AppWithCallbackAfterRender` component into the DOM, has been replaced with the `ReactDOM.createRoot().render` method. 

   The `createRoot()` method is the new concurrent mode API in React 18.x. It replaces the old `ReactDOM.render()` method. It prepares a DOM container where the React elements can be rendered.

   This method creates a root on the specified container and then returns an object with a render method, which is then used to render the `<App />` component. 

3. The `useEffect` hook, which was used to log a message after the component was rendered, is no longer needed because the `ReactDOM.createRoot().render` method does not require a callback function. This is because rendering in concurrent mode is not blocking and does not provide such a callback.

4. The import statement for `React` remains unchanged, but the import for `useEffect` is removed as it's no longer used.

5. The `registerServiceWorker()` call is unchanged. It's used to register a service worker for offline capabilities of the app.