### PR TITLE
test: Upgrade react to 18 on branch smartshift-thomasuster-1691438982

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,9 @@
       "name": "my-app",
       "version": "0.1.0",
       "dependencies": {
-        "react": "^15.6.1",
-        "react-dom": "^15.6.1",
-        "react-scripts": "1.0.10"
+        "react": "^18.2.0",
+        "react-dom": "^15.7.0",
+        "react-scripts": "^1.0.10"
       }
     },
     "node_modules/abab": {
@@ -2931,15 +2931,6 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
-      }
-    },
-    "node_modules/create-react-class": {
-      "version": "15.7.0",
-      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.7.0.tgz",
-      "integrity": "sha512-QZv4sFWG9S5RUvkTYWbflxeZX+JG7Cz0Tn33rQBJ+WFQTqTfUTjMjiv9tnfXazjsO5r0KhPs+AqCjyrQX6h2ng==",
-      "dependencies": {
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
       }
     },
     "node_modules/cross-spawn": {
@@ -11073,15 +11064,11 @@
       }
     },
     "node_modules/react": {
-      "version": "15.7.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-15.7.0.tgz",
-      "integrity": "sha512-5/MMRYmpmM0sMTHGLossnJCrmXQIiJilD6y3YN3TzAwGFj6zdnMtFv6xmi65PHKRV+pehIHpT7oy67Sr6s9AHA==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "dependencies": {
-        "create-react-class": "^15.6.0",
-        "fbjs": "^0.8.9",
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.0",
-        "prop-types": "^15.5.10"
+        "loose-envify": "^1.1.0"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -15512,8 +15499,7 @@
     "ajv-keywords": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-      "integrity": "sha512-vuBv+fm2s6cqUyey2A7qYcvsik+GMDJsw8BARP2sDE76cqmaZVarsvHf7Vx6VJ0Xk8gLl+u3MoAPf6gKzJefeA==",
-      "requires": {}
+      "integrity": "sha512-vuBv+fm2s6cqUyey2A7qYcvsik+GMDJsw8BARP2sDE76cqmaZVarsvHf7Vx6VJ0Xk8gLl+u3MoAPf6gKzJefeA=="
     },
     "align-text": {
       "version": "0.1.4",
@@ -17934,15 +17920,6 @@
         "sha.js": "^2.4.8"
       }
     },
-    "create-react-class": {
-      "version": "15.7.0",
-      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.7.0.tgz",
-      "integrity": "sha512-QZv4sFWG9S5RUvkTYWbflxeZX+JG7Cz0Tn33rQBJ+WFQTqTfUTjMjiv9tnfXazjsO5r0KhPs+AqCjyrQX6h2ng==",
-      "requires": {
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
-      }
-    },
     "cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
@@ -18788,8 +18765,7 @@
     "eslint-config-react-app": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-1.0.5.tgz",
-      "integrity": "sha512-nA3AYTMUGKVYH1goOp72fFdj33mxC1rElATOLDrCMbbhmtVz4K61NxKBc6vj9OwjugROioF2LYXZMZIFAfFozA==",
-      "requires": {}
+      "integrity": "sha512-nA3AYTMUGKVYH1goOp72fFdj33mxC1rElATOLDrCMbbhmtVz4K61NxKBc6vj9OwjugROioF2LYXZMZIFAfFozA=="
     },
     "eslint-import-resolver-node": {
       "version": "0.2.3",
@@ -24370,15 +24346,11 @@
       }
     },
     "react": {
-      "version": "15.7.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-15.7.0.tgz",
-      "integrity": "sha512-5/MMRYmpmM0sMTHGLossnJCrmXQIiJilD6y3YN3TzAwGFj6zdnMtFv6xmi65PHKRV+pehIHpT7oy67Sr6s9AHA==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "requires": {
-        "create-react-class": "^15.6.0",
-        "fbjs": "^0.8.9",
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.0",
-        "prop-types": "^15.5.10"
+        "loose-envify": "^1.1.0"
       }
     },
     "react-dev-utils": {

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "react": "^15.6.1",
-    "react-dom": "^15.6.1",
-    "react-scripts": "1.0.10"
+    "react": "^18.2.0",
+    "react-dom": "^15.7.0",
+    "react-scripts": "^1.0.10"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,9 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import App from './App';
 
 it('renders without crashing', () => {
   const div = document.createElement('div');
-  ReactDOM.render(<App />, div);
+  const root = createRoot(div);
+  root.render(<App />);
 });

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,10 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App';
 import registerServiceWorker from './registerServiceWorker';
 
-ReactDOM.render(<App />, document.getElementById('root'));
+const container = document.getElementById('root');
+const root = createRoot(container);
+root.render(<App />);
 registerServiceWorker();


### PR DESCRIPTION
# test
## Tasks
### Handle Deprecations
Several ReactDOM methods have been deprecated in React 18

#### Instructions
- Replace ReactDOM.render with ReactDOM.createRoot
    - src/App.test.js
    - src/index.js
### Update Client Rendering APIs
React 18 introduces a new root API which provides better ergonomics for managing roots. The new root API also enables the new concurrent renderer, which allows you to opt-into concurrent features.

#### Instructions
- If using render imported from react-dom, replace it with createRoot
    - src/App.test.js
    - src/index.js
### Upgrade react


#### Instructions
- Run package commands to upgrade react
    - migrations/test/switchkeep/sample-react17-app/package-lock.json
    - migrations/test/switchkeep/sample-react17-app/package.json

## Errors

### Update Client Rendering APIs
React 18 introduces a new root API which provides better ergonomics for managing roots. The new root API also enables the new concurrent renderer, which allows you to opt-into concurrent features.

#### Instructions
- If using render imported from react-dom, replace it with createRoot
    - migrations/test/switchkeep/sample-react17-app/src/TooBigFile.js: migrations/test/switchkeep/sample-react17-app/src/TooBigFile.js for task: Update Client Rendering APIs, step: If using render imported from react-dom, replace it with createRoot error: exceeds 2000 tokens and not currently supported. 

### Handle Deprecations
Several ReactDOM methods have been deprecated in React 18

#### Instructions
- Replace ReactDOM.render with ReactDOM.createRoot
    - migrations/test/switchkeep/sample-react17-app/src/TooBigFile.js: migrations/test/switchkeep/sample-react17-app/src/TooBigFile.js for task: Handle Deprecations, step: Replace ReactDOM.render with ReactDOM.createRoot error: exceeds 2000 tokens and not currently supported. 
